### PR TITLE
Do not connect Qt signal directly to EventEmitter.

### DIFF
--- a/bluesky_widgets_demo/qt_viewer_with_search.py
+++ b/bluesky_widgets_demo/qt_viewer_with_search.py
@@ -50,7 +50,10 @@ class QtSearchListWithButton(QWidget):
 
         go_button = QPushButton("View Selected Runs")
         layout.addWidget(go_button)
-        go_button.clicked.connect(self.model.events.view)
+        go_button.clicked.connect(self._on_go_button_clicked)
+
+    def _on_go_button_clicked(self):
+        self.model.events.view()
 
 
 class SearchAndView:


### PR DESCRIPTION
Current `master` branch: clicking the button causes an error message in the terminal (and no plot).

```
QLayout: Attempting to add QLayout "" to QtSearchInput "", which already has a layout
Traceback (most recent call last):
  File "/home/dallan/Repos/bnl/bluesky-live/bluesky_live/event.py", line 476, in __call__
    event = self._prepare_event(*args, **kwargs)
  File "/home/dallan/Repos/bnl/bluesky-live/bluesky_live/event.py", line 539, in _prepare_event
    raise ValueError(
ValueError: Event emitters can be called with an Event instance or with keyword arguments only.
```

This PR restores working behavior.

Why did this used to work as is? Previously, `EventEmitters` silently ignored any positional arguments passed. Now, they raise, and so we need to add any intermediate method.