### PR TITLE
Connect RunEngine worker

### DIFF
--- a/bluesky_widgets_demo/main.py
+++ b/bluesky_widgets_demo/main.py
@@ -10,7 +10,8 @@ def main(argv=None):
     print(__doc__)
 
     parser = argparse.ArgumentParser(description="bluesky-widgets demo")
-    parser.add_argument("--zmq", help="0MQ address")
+    parser.add_argument("--document-stream", nargs="*", help="Address of streaming data source, e.g. zmq://...")
+    parser.add_argument("--run-engine-worker", help="Address of RunEngine worker, e.g. zmq://...")
     parser.add_argument("--catalog", help="Databroker catalog")
     args = parser.parse_args(argv)
 
@@ -19,10 +20,8 @@ def main(argv=None):
             import databroker
 
             SETTINGS.catalog = databroker.catalog[args.catalog]
-
-        # Optional: Receive live streaming data.
-        if args.zmq:
-            SETTINGS.subscribe_to.append(args.zmq)
+        SETTINGS.subscribe_to.extend(args.document_stream or [])
+        SETTINGS.run_engine_worker_address = args.run_engine_worker
         viewer = Viewer()  # noqa: 401
 
 

--- a/bluesky_widgets_demo/models.py
+++ b/bluesky_widgets_demo/models.py
@@ -16,6 +16,9 @@ class SearchWithButton(Search):
 
 
 class SearchAndView:
+    """
+    A model that pushes search results into auto-plots when a signal (e.g. button click) fires
+    """
     def __init__(self, search, auto_plot_builder):
         self.search = search
         self.auto_plot_builder = auto_plot_builder

--- a/bluesky_widgets_demo/settings.py
+++ b/bluesky_widgets_demo/settings.py
@@ -39,9 +39,17 @@ columns = (headings, extract_results_row_from_run)
 
 
 class Settings:
+    """
+    This is used by the ViewerModel at __init__ time to configure itself.
+
+    The instance below, SETTINGS, is modified by the argparser before that
+    happens. We may want to rethink exactly where and how this configuration
+    injection works.
+    """
     columns = columns
     catalog = None
     subscribe_to = []
+    run_engine_worker_address = None
 
 
 SETTINGS = Settings()

--- a/bluesky_widgets_demo/viewer.py
+++ b/bluesky_widgets_demo/viewer.py
@@ -9,13 +9,22 @@ from .settings import SETTINGS
 
 class ViewerModel:
     """
-    This encapsulates on the models in the application.
+    This encapsulates all the models in the application.
     """
 
-    def __init__(self):
+    def __init__(self, title="Demo App"):
+        # TODO We can remove SETTINGS here and make this cleaner once all of
+        # the relevant parameters are runtime-settable, as in
+        # self.search.catalog = ...
+        # and
+        # self.search.columns = ...
+        # Once that is possible, the argparser and other entrypoints can instantiate
+        # the app and then configure the instance without the potentially-confusing
+        # SETTINGS side-band.
+        self.title = title
         self.search = SearchWithButton(SETTINGS.catalog, columns=SETTINGS.columns)
         self.auto_plot_builder = AutoLines(max_runs=3)
-        self.run_engine = RunEngineClient()  # TODO Address?
+        self.run_engine = RunEngineClient(SETTINGS.run_engine_worker_address)
 
 
 class Viewer(ViewerModel):
@@ -26,8 +35,7 @@ class Viewer(ViewerModel):
     """
 
     def __init__(self, *, show=True, title="Demo App"):
-        # TODO Where does title thread through?
-        super().__init__()
+        super().__init__(title=title)
         if SETTINGS.subscribe_to:
             from bluesky_widgets.qt.zmq_dispatcher import RemoteDispatcher
             from bluesky_widgets.utils.streaming import (


### PR DESCRIPTION
This exposes a CLI argument to provider the RunEngine worker address.

For document streams, we intend to support `zmq://...` and `kafka://...`. For consistency, it probably makes sense to spell the RunEngine worker address as `zmq://...` as well. (And this leaves an easy path to support `http://...` --- the full queueserver --- in the future.)

But pyzmq blows up at this:

```
zmq.error.ZMQError: Protocol not supported
```

I guess we should just strip the `zmq://` off. Is there a standard scheme for ZeroMQ that we should be using instead?