### PR TITLE
Demo of widgets for controlling RE Manager

### DIFF
--- a/bluesky_widgets_demo/widgets.py
+++ b/bluesky_widgets_demo/widgets.py
@@ -11,6 +11,7 @@ from bluesky_widgets.qt.run_engine_client import (
     QtReQueueControls,
     QtReExecutionControls,
     QtReStatusMonitor,
+    QtRePlanQueue,
 )
 from qtpy.QtWidgets import (
     QWidget,
@@ -148,7 +149,12 @@ class QtRunEngineManager(QWidget):
 
         hbox.addStretch()
         vbox.addLayout(hbox)
-        vbox.addStretch()
+
+        hbox = QHBoxLayout()
+        hbox.addWidget(QtRePlanQueue(model))
+        hbox.addStretch()
+        vbox.addLayout(hbox)
+        # vbox.addStretch()
         self.setLayout(vbox)
 
 

--- a/bluesky_widgets_demo/widgets.py
+++ b/bluesky_widgets_demo/widgets.py
@@ -10,6 +10,7 @@ from bluesky_widgets.qt.run_engine_client import (
     QtReManagerConnection,
     QtReQueueControls,
     QtReExecutionControls,
+    QtReStatusMonitor,
 )
 from qtpy.QtWidgets import (
     QWidget,
@@ -143,6 +144,8 @@ class QtRunEngineManager(QWidget):
         hbox.addWidget(QtReEnvironmentControls(model))
         hbox.addWidget(QtReQueueControls(model))
         hbox.addWidget(QtReExecutionControls(model))
+        hbox.addWidget(QtReStatusMonitor(model))
+
         hbox.addStretch()
         vbox.addLayout(hbox)
         vbox.addStretch()

--- a/bluesky_widgets_demo/widgets.py
+++ b/bluesky_widgets_demo/widgets.py
@@ -12,6 +12,7 @@ from bluesky_widgets.qt.run_engine_client import (
     QtReExecutionControls,
     QtReStatusMonitor,
     QtRePlanQueue,
+    QtRePlanHistory,
 )
 from qtpy.QtWidgets import (
     QWidget,
@@ -152,7 +153,7 @@ class QtRunEngineManager(QWidget):
 
         hbox = QHBoxLayout()
         hbox.addWidget(QtRePlanQueue(model))
-        hbox.addStretch()
+        hbox.addWidget(QtRePlanHistory(model))
         vbox.addLayout(hbox)
         # vbox.addStretch()
         self.setLayout(vbox)

--- a/bluesky_widgets_demo/widgets.py
+++ b/bluesky_widgets_demo/widgets.py
@@ -13,6 +13,7 @@ from bluesky_widgets.qt.run_engine_client import (
     QtReStatusMonitor,
     QtRePlanQueue,
     QtRePlanHistory,
+    QtReRunningPlan,
 )
 from qtpy.QtWidgets import (
     QWidget,
@@ -152,10 +153,12 @@ class QtRunEngineManager(QWidget):
         vbox.addLayout(hbox)
 
         hbox = QHBoxLayout()
-        hbox.addWidget(QtRePlanQueue(model))
+        vbox1 = QVBoxLayout()
+        vbox1.addWidget(QtReRunningPlan(model), stretch=1)
+        vbox1.addWidget(QtRePlanQueue(model), stretch=2)
+        hbox.addLayout(vbox1)
         hbox.addWidget(QtRePlanHistory(model))
         vbox.addLayout(hbox)
-        # vbox.addStretch()
         self.setLayout(vbox)
 
 

--- a/bluesky_widgets_demo/widgets.py
+++ b/bluesky_widgets_demo/widgets.py
@@ -8,6 +8,7 @@ from bluesky_widgets.qt.figures import QtFigures
 from bluesky_widgets.qt.run_engine_client import (
     QtReEnvironmentControls,
     QtReManagerConnection,
+    QtReQueueControls,
     QtReExecutionControls,
 )
 from qtpy.QtWidgets import (
@@ -140,6 +141,7 @@ class QtRunEngineManager(QWidget):
         hbox = QHBoxLayout()
         hbox.addWidget(QtReManagerConnection(model))
         hbox.addWidget(QtReEnvironmentControls(model))
+        hbox.addWidget(QtReQueueControls(model))
         hbox.addWidget(QtReExecutionControls(model))
         hbox.addStretch()
         vbox.addLayout(hbox)


### PR DESCRIPTION
In this PR a number of widgets for control RE Manager are added to the demo application:

- widget for starting and stopping the queue (`QtReQueueControls`).

- widget for monitoring RE Manager status (`QtReStatusMonitor`).

