### PR TITLE
FIX: avoid crashing with empty catalog

### DIFF
--- a/bluesky_widgets_demo/models.py
+++ b/bluesky_widgets_demo/models.py
@@ -22,5 +22,8 @@ class SearchAndView:
         self.search.events.view.connect(self._on_view)
 
     def _on_view(self, event):
-        for uid, run in self.search.selection_as_catalog.items():
+        catalog = self.search.selection_as_catalog
+        if catalog is None:
+            return
+        for uid, run in catalog.items():
             self.auto_plot_builder.add_run(run, pinned=True)

--- a/bluesky_widgets_demo/widgets.py
+++ b/bluesky_widgets_demo/widgets.py
@@ -43,7 +43,9 @@ class QtSearchWithButton(QWidget):
         go_button.clicked.connect(self._on_go_button_clicked)
 
     def _on_go_button_clicked(self):
-        self.model.events.view()
+        events = self.model.events
+        if events is not None:
+            events.view()
 
 
 class QtAddCustomPlot(QWidget):


### PR DESCRIPTION
Failure to handle `None` in two places found during testing.