### PR TITLE
Registering the Plan Editor with the Plan Queue widget

### DIFF
--- a/bluesky_widgets_demo/widgets.py
+++ b/bluesky_widgets_demo/widgets.py
@@ -170,8 +170,14 @@ class QtRunEngineManager(QWidget):
 
         hbox = QHBoxLayout()
         vbox1 = QVBoxLayout()
-        vbox1.addWidget(QtRePlanEditor(model), stretch=1)
-        vbox1.addWidget(QtRePlanQueue(model), stretch=1)
+
+        # Register plan editor (opening plans in the editor by double-clicking the plan in the table)
+        pe = QtRePlanEditor(model)
+        pq = QtRePlanQueue(model)
+        pq.register_item_editor(pe.edit_queue_item)
+
+        vbox1.addWidget(pe, stretch=1)
+        vbox1.addWidget(pq, stretch=1)
         hbox.addLayout(vbox1)
         vbox2 = QVBoxLayout()
         vbox2.addWidget(QtReRunningPlan(model), stretch=1)

--- a/bluesky_widgets_demo/widgets.py
+++ b/bluesky_widgets_demo/widgets.py
@@ -174,7 +174,7 @@ class QtRunEngineManager(QWidget):
         # Register plan editor (opening plans in the editor by double-clicking the plan in the table)
         pe = QtRePlanEditor(model)
         pq = QtRePlanQueue(model)
-        pq.register_item_editor(pe.edit_queue_item)
+        pq.registered_item_editors.append(pe.edit_queue_item)
 
         vbox1.addWidget(pe, stretch=1)
         vbox1.addWidget(pq, stretch=1)


### PR DESCRIPTION
Register Plan Editor with the Plan Queue Widget. Items can be opened in the Plan Editor by double-clicking on the respective row in Plan Queue Widget.

Requires changes in PR https://github.com/bluesky/bluesky-widgets/pull/145 