### PR TITLE
Include `QtReConsoleMonitor` widget in the demo

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -7,4 +7,5 @@ exclude =
     versioneer.py,
     bluesky_widgets_demo/_version.py,
     docs/source/conf.py
+ignore = E203, W503  # There are some errors produced by 'black', therefore unavoidable
 max-line-length = 115

--- a/bluesky_widgets_demo/main.py
+++ b/bluesky_widgets_demo/main.py
@@ -23,6 +23,7 @@ def main(argv=None):
         # Optional: Receive live streaming data.
         if args.zmq:
             SETTINGS.subscribe_to.append(args.zmq)
+
         viewer = Viewer()  # noqa: 401
 
 

--- a/bluesky_widgets_demo/viewer.py
+++ b/bluesky_widgets_demo/viewer.py
@@ -20,6 +20,7 @@ class ViewerModel:
 
         self.run_engine = RunEngineClient(
             zmq_server_address=os.environ.get("QSERVER_ZMQ_ADDRESS", None),
+            zmq_subscribe_address=os.environ.get("QSERVER_ZMQ_CONSOLE_ADDRESS", None),
         )
 
 

--- a/bluesky_widgets_demo/widgets.py
+++ b/bluesky_widgets_demo/widgets.py
@@ -15,6 +15,7 @@ from bluesky_widgets.qt.run_engine_client import (
     QtRePlanHistory,
     QtReRunningPlan,
     QtRePlanEditor,
+    QtReConsoleMonitor,
 )
 from qtpy.QtWidgets import (
     QWidget,
@@ -182,6 +183,7 @@ class QtRunEngineManager(QWidget):
         vbox2 = QVBoxLayout()
         vbox2.addWidget(QtReRunningPlan(model), stretch=1)
         vbox2.addWidget(QtRePlanHistory(model), stretch=2)
+        vbox2.addWidget(QtReConsoleMonitor(model), stretch=1)
         hbox.addLayout(vbox2)
         vbox.addLayout(hbox)
         self.setLayout(vbox)


### PR DESCRIPTION
Include `QtReConsoleMonitor` widget for monitoring captured console output in the demo. Queue server must be started with `--zmq-publish ON` to enable publishing of the console output.