### PR TITLE
Pass RE Manager addresses as CLI parameters or environment variables

### DIFF
--- a/bluesky_widgets_demo/main.py
+++ b/bluesky_widgets_demo/main.py
@@ -21,14 +21,16 @@ def main(argv=None):
         "QSERVER_ZMQ_CONTROL_ADDRESS environment variable. Default address is "
         "used if the parameter or the environment variable are not specified.",
     )
-    # parser.add_argument(
-    #     "--zmq-info-addr",
-    #     default=None,
-    #     help="Address of PUB-SUB socket of RE Manager. If the address is passed as ""
-    #     "a CLI parameter, it overrides the address specified with "
-    #     "QSERVER_ZMQ_INFO_ADDRESS environment variable. Default address is "
-    #     "used if the parameter or the environment variable are not specified.",
-    # )
+    parser.add_argument(
+        "--zmq-info-addr",
+        default=None,
+        help="Address of PUB-SUB socket of RE Manager. If the address is passed as "
+        "a CLI parameter, it overrides the address specified with "
+        "QSERVER_ZMQ_INFO_ADDRESS environment variable. Default address is "
+        "used if the parameter or the environment variable are not specified.",
+    )
+
+    parser.add_argument("--zmq-doc-addr", help="0MQ address: for stream of databroker documents")
 
     parser.add_argument("--catalog", help="Databroker catalog")
     args = parser.parse_args(argv)
@@ -36,8 +38,10 @@ def main(argv=None):
     zmq_control_addr = args.zmq_control_addr
     zmq_control_addr = zmq_control_addr or os.environ.get("QSERVER_ZMQ_CONTROL_ADDRESS", None)
 
-    # zmq_info_addr = args.zmq_info_addr
-    # zmq_info_addr = zmq_info_addr or os.environ.get("QSERVER_ZMQ_INFO_ADDRESS", None)
+    zmq_info_addr = args.zmq_info_addr
+    zmq_info_addr = zmq_info_addr or os.environ.get("QSERVER_ZMQ_INFO_ADDRESS", None)
+
+    zmq_doc_addr = args.zmq_doc_addr
 
     with gui_qt("Demo App"):
         if args.catalog:
@@ -47,7 +51,10 @@ def main(argv=None):
 
         # Optional: Receive live streaming data.
         if args.zmq:
-            SETTINGS.subscribe_to.append(zmq_control_addr)
+            SETTINGS.subscribe_to.append(zmq_doc_addr)
+
+        SETTINGS.zmq_re_manager_control_addr = zmq_control_addr
+        SETTINGS.zmq_re_manager_info_addr = zmq_info_addr
 
         viewer = Viewer()  # noqa: 401
 

--- a/bluesky_widgets_demo/main.py
+++ b/bluesky_widgets_demo/main.py
@@ -2,6 +2,8 @@ import argparse
 
 from bluesky_widgets.qt import gui_qt
 
+import os
+
 from .viewer import Viewer
 from .settings import SETTINGS
 
@@ -10,9 +12,32 @@ def main(argv=None):
     print(__doc__)
 
     parser = argparse.ArgumentParser(description="bluesky-widgets demo")
-    parser.add_argument("--zmq", help="0MQ address")
+
+    parser.add_argument(
+        "--zmq-control-addr",
+        default=None,
+        help="Address of control socket of RE Manager. If the address "
+        "is passed as a CLI parameter, it overrides the address specified with "
+        "QSERVER_ZMQ_CONTROL_ADDRESS environment variable. Default address is "
+        "used if the parameter or the environment variable are not specified.",
+    )
+    # parser.add_argument(
+    #     "--zmq-info-addr",
+    #     default=None,
+    #     help="Address of PUB-SUB socket of RE Manager. If the address is passed as ""
+    #     "a CLI parameter, it overrides the address specified with "
+    #     "QSERVER_ZMQ_INFO_ADDRESS environment variable. Default address is "
+    #     "used if the parameter or the environment variable are not specified.",
+    # )
+
     parser.add_argument("--catalog", help="Databroker catalog")
     args = parser.parse_args(argv)
+
+    zmq_control_addr = args.zmq_control_addr
+    zmq_control_addr = zmq_control_addr or os.environ.get("QSERVER_ZMQ_CONTROL_ADDRESS", None)
+
+    # zmq_info_addr = args.zmq_info_addr
+    # zmq_info_addr = zmq_info_addr or os.environ.get("QSERVER_ZMQ_INFO_ADDRESS", None)
 
     with gui_qt("Demo App"):
         if args.catalog:
@@ -22,7 +47,7 @@ def main(argv=None):
 
         # Optional: Receive live streaming data.
         if args.zmq:
-            SETTINGS.subscribe_to.append(args.zmq)
+            SETTINGS.subscribe_to.append(zmq_control_addr)
 
         viewer = Viewer()  # noqa: 401
 

--- a/bluesky_widgets_demo/settings.py
+++ b/bluesky_widgets_demo/settings.py
@@ -42,6 +42,8 @@ class Settings:
     columns = columns
     catalog = None
     subscribe_to = []
+    zmq_re_manager_control_addr = None
+    zmq_re_manager_info_addr = None
 
 
 SETTINGS = Settings()

--- a/bluesky_widgets_demo/viewer.py
+++ b/bluesky_widgets_demo/viewer.py
@@ -1,5 +1,3 @@
-import os
-
 from bluesky_widgets.models.auto_plot_builders import AutoLines, AutoImages
 from bluesky_widgets.models.run_engine_client import RunEngineClient
 from bluesky_widgets.qt import Window
@@ -19,8 +17,8 @@ class ViewerModel:
         self.auto_plot_builders = [AutoLines(max_runs=3), AutoImages(max_runs=1)]
 
         self.run_engine = RunEngineClient(
-            zmq_server_address=os.environ.get("QSERVER_ZMQ_ADDRESS", None),
-            zmq_subscribe_address=os.environ.get("QSERVER_ZMQ_CONSOLE_ADDRESS", None),
+            zmq_control_addr=SETTINGS.zmq_re_manager_control_addr,
+            zmq_info_addr=SETTINGS.zmq_re_manager_info_addr,
         )
 
 


### PR DESCRIPTION
The addresses of RE Manager control and information sockets could be passed as CLI parameters `--zmq-control-addr` and `--zmq-info-addr` or as environment variables `QSERVER_ZMQ_CONTROL_ADDR` and `QSERVER_ZMQ_INFO_ADDR`.